### PR TITLE
fix: use critical section for reading bits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "http://github.com/DaneSlattery/hx711"
 description = "A no-std embedded-hal package for the hx711 load cell, based on the embedded hal. Has optional support for interrupts on the esp32."
 
 [dependencies]
+critical-section = "1.1.2"
 embedded-hal = { version = "0.2.7", features = ["unproven"] }
 esp32-hal = { version = "0.15.0", optional = true }
 


### PR DESCRIPTION
Closes https://github.com/DaneSlattery/hx711/issues/4

As explained in the issue, any interrupt defined by the user (e.g. a timer) could potentially trigger while the SCK pin is high, thus delaying the reading of the data pin and making the amplifier enter power down mode. This results in wrong data being read by the library.

The solution is to make sure the reading of the bits happens in a critical section, where interrupts have been disabled.
The `critical-section` crate provides a portable interface to describe this behavior, without providing an actual implementation (which would be platform-dependent).

Most, if not all HAL crates implement the required traits from `critical-section` so that interrupts are correctly paused.

This fork has been tested with `esp-idf-hal` but should work with any HAL that has an implementation of critical section.