### PR TITLE
Update to latest embedded-hal, include std example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "byteorder"
@@ -117,14 +117,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-executor"
-version = "0.4.0"
+name = "document-features"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94598b92a396f27bd34a4ce2648c35d5fec7c7157c1a4e3160167ca39c3e116c"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec648daedd2143466eff4b3e8002024f9f6c1de4ab7666bb679688752624c925"
 dependencies = [
  "critical-section",
+ "document-features",
  "embassy-executor-macros",
- "embassy-time",
+ "embassy-time-driver",
+ "embassy-time-queue-driver",
 ]
 
 [[package]]
@@ -140,18 +151,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-time"
-version = "0.2.0"
+name = "embassy-time-driver"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a2fc78331899dc7ba8fbcae2fcac3f5cd5301c0717689c546af2ce4162d4e4"
+checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
 dependencies = [
- "cfg-if",
- "critical-section",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0-rc.2",
- "embedded-hal-async",
- "futures-util",
- "heapless",
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
+
+[[package]]
+name = "embedded-can"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d2e857f87ac832df68fa498d18ddc679175cf3d2e4aa893988e5601baf9438"
+dependencies = [
+ "nb 1.1.0",
 ]
 
 [[package]]
@@ -175,17 +195,18 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e57ec6ad0bc8eb967cf9c9f144177f5e8f2f6f02dad0b8b683f9f05f6b22def"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
-name = "embedded-hal-async"
-version = "1.0.0-rc.2"
+name = "embedded-hal-nb"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5ad4a01f9cb38117ef85f5cd32176d63875e7eab99c5b60e8492bfdc16dd63"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
 dependencies = [
- "embedded-hal 1.0.0-rc.2",
+ "embedded-hal 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
@@ -229,18 +250,18 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "esp-backtrace"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7d3ecccb0df809cb6ca79b08f863271c0aa24f586df96272988a85d34dfa62"
+checksum = "7c5c6f9166728f6cd08e5781899f4c94fd7ccf2efd04e5b2295f7cb2c92c83e8"
 dependencies = [
  "esp-println",
 ]
 
 [[package]]
 name = "esp-hal-common"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e9f181669edeb35ef6d6c5518c9941900dbf2133348673eebb4b33fb73ac62"
+checksum = "c468eb364cc570da74dfb8adfda9f308c34259fcd19a4c695a46554a26b7478a"
 dependencies = [
  "basic-toml",
  "bitfield",
@@ -248,11 +269,16 @@ dependencies = [
  "cfg-if",
  "critical-section",
  "embassy-executor",
+ "embedded-can",
  "embedded-dma",
  "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-nb",
  "enumset",
  "esp-hal-procmacros",
  "esp32",
+ "esp32s2",
+ "esp32s3",
  "fugit",
  "heapless",
  "nb 1.1.0",
@@ -282,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "esp-println"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b429ea925356d60c10d7214cf0e1777d9578c1287cd50aad09df3c22c4c2f1"
+checksum = "6e090867a191aaaa0645f8a7f03c51ab57cee82e2adba5525940dc9ff1c07511"
 dependencies = [
  "critical-section",
  "log",
@@ -303,11 +329,33 @@ dependencies = [
 
 [[package]]
 name = "esp32-hal"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1a4dd97ac2ea1572434d5353a6bdeb86072d7864f9018221e7a04b5aa52689"
+checksum = "9ac3605edffa326244eac0afc66f3f6af81c84e91b4bb63a1e26ca36a3db7fd6"
 dependencies = [
  "esp-hal-common",
+]
+
+[[package]]
+name = "esp32s2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b31f5a118f20eac1f38d155432ad976b777229dbaf050fecf1d1a61cf3295a"
+dependencies = [
+ "critical-section",
+ "vcell",
+ "xtensa-lx",
+]
+
+[[package]]
+name = "esp32s3"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5227feb6445b9eb8482f0a3eca3a0891df21a18b3d1c6e45fa6f09a5267b9711"
+dependencies = [
+ "critical-section",
+ "vcell",
+ "xtensa-lx",
 ]
 
 [[package]]
@@ -323,30 +371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
 dependencies = [
  "gcd",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-task"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
-
-[[package]]
-name = "futures-util"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
 ]
 
 [[package]]
@@ -416,7 +440,7 @@ name = "loadcell"
 version = "0.2.0"
 dependencies = [
  "critical-section",
- "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
  "esp-backtrace",
  "esp-println",
  "esp32-hal",
@@ -480,18 +504,6 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,30 +11,26 @@ keywords = ["scale", "hx711", "loadcell", "no-std", "driver"]
 categories = ["no-std", "embedded", "hardware-support", "science::robotics"]
 
 [dependencies]
+esp32-hal = { version = "0.18.0", optional = true, features = ["eh1"] }
 critical-section = "1.1.2"
-embedded-hal = { version = "0.2.7", features = ["unproven"] }
-esp32-hal = { version = "0.17.0", optional = true }
+embedded-hal = { version = "1.0.0" }
 
 [features]
 default = []
 esp32_interrupt = ["esp32-hal"]
 
-
 [[example]]
 name = "interrupt"
 required-features = ["esp32_interrupt"]
 
-[[example]]
-name = "polling"
-required-features = ["esp32_interrupt"]
 
 [dev-dependencies]
-esp-backtrace = { version = "0.8.0", features = [
+esp-backtrace = { version = "0.11.0", features = [
     "esp32",
     "panic-handler",
     "exception-handler",
-    "print-uart",
+    "println",
 ] }
-esp-println = { version = "0.6.0", features = ["esp32", "log"] }
+esp-println = { version = "0.9.0", features = ["esp32", "log"] }
 log = { version = "0.4.18" }
 critical-section = "1.1.2"

--- a/examples/interrupt.rs
+++ b/examples/interrupt.rs
@@ -40,7 +40,7 @@ static HX711_MUTEX: Mutex<RefCell<Option<HX711<SckPin, DTPin, Delay>>>> =
 #[entry]
 fn main() -> ! {
     let peripherals = Peripherals::take();
-    let system = peripherals.DPORT.split();
+    let system = peripherals.SYSTEM.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
     let mut delay = Delay::new(&clocks);
 

--- a/examples/polling.rs
+++ b/examples/polling.rs
@@ -11,7 +11,7 @@ use loadcell::{hx711, LoadCell};
 #[entry]
 fn main() -> ! {
     let periph = Peripherals::take();
-    let system = periph.DPORT.split();
+    let system = periph.SYSTEM.split();
 
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 

--- a/examples/polling_idf.rs
+++ b/examples/polling_idf.rs
@@ -1,0 +1,25 @@
+// currently does not build in in this no-std environment. copy the code elsewhere
+use esp_idf_svc::hal::{delay, gpio::PinDriver, peripherals::Peripherals};
+use loadcell::{hx711::HX711, LoadCell};
+
+fn main() {
+    esp_idf_svc::sys::link_patches();
+    esp_idf_svc::log::EspLogger::initialize_default();
+
+    let peripherals = Peripherals::take().unwrap();
+    let dt = PinDriver::input(peripherals.pins.gpio1).unwrap();
+    let sck = PinDriver::output(peripherals.pins.gpio10).unwrap();
+    let mut load_sensor = HX711::new(sck, dt, delay::FreeRtos);
+
+    load_sensor.tare(16);
+    load_sensor.set_scale(1.0);
+
+    loop {
+        if load_sensor.is_ready() {
+            let reading = load_sensor.read_scaled();
+            log::info!("Last Reading = {:?}", reading);
+        }
+
+        delay::FreeRtos::delay_ms(1000u32);
+    }
+}

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -10,9 +10,8 @@ pub mod interrupt;
 #[cfg(feature = "esp32_interrupt")]
 pub use interrupt::*;
 
-use embedded_hal::blocking::delay::DelayUs;
-
-use embedded_hal::digital::v2::{InputPin, OutputPin};
+use embedded_hal::delay::DelayNs;
+use embedded_hal::digital::{InputPin, OutputPin};
 
 #[cfg(feature = "default")]
 use crate::LoadCell;
@@ -46,7 +45,7 @@ pub struct HX711<SckPin, DTPin, Delay>
 where
     SckPin: OutputPin,
     DTPin: InputPin,
-    Delay: DelayUs<u32>,
+    Delay: DelayNs,
 {
     sck_pin: SckPin,
     dt_pin: DTPin,
@@ -72,7 +71,7 @@ impl<SckPin, DTPin, Delay, ESCK, EDT> HX711<SckPin, DTPin, Delay>
 where
     SckPin: OutputPin<Error = ESCK>,
     DTPin: InputPin<Error = EDT>,
-    Delay: DelayUs<u32>,
+    Delay: DelayNs,
     EDT: fmt::Debug,
     ESCK: fmt::Debug,
 {
@@ -91,7 +90,7 @@ where
     }
 
     /// Returns true if the load cell amplifier has a value ready to be read.
-    pub fn is_ready(&self) -> bool {
+    pub fn is_ready(&mut self) -> bool {
         self.dt_pin.is_low().unwrap()
     }
 
@@ -178,7 +177,7 @@ impl<SckPin, DTPin, Delay, ESCK, EDT> LoadCell for HX711<SckPin, DTPin, Delay>
 where
     SckPin: OutputPin<Error = ESCK>,
     DTPin: InputPin<Error = EDT>,
-    Delay: DelayUs<u32>,
+    Delay: DelayNs,
     ESCK: fmt::Debug,
     EDT: fmt::Debug,
 {

--- a/src/hx711/interrupt.rs
+++ b/src/hx711/interrupt.rs
@@ -30,9 +30,9 @@ pub trait Interrupt: LoadCell {
 #[cfg(feature = "esp32_interrupt")]
 impl<SckPin, DTPin, Delay> Interrupt for HX711<SckPin, DTPin, Delay>
 where
-    SckPin: OutputPin + embedded_hal::digital::v2::OutputPin<Error = Infallible>,
-    DTPin: InputPin + embedded_hal::digital::v2::InputPin<Error = Infallible>,
-    Delay: embedded_hal::blocking::delay::DelayUs<u32>,
+    SckPin: OutputPin + embedded_hal::digital::OutputPin<Error = Infallible>,
+    DTPin: InputPin + embedded_hal::digital::InputPin<Error = Infallible>,
+    Delay: embedded_hal::delay::DelayNs,
 {
     fn tare_sync(&mut self, num_samples: usize) {
         let mut was_listening = false;


### PR DESCRIPTION
Fixes examples
Adds a std example, although this does not build in this environment.
Upgrades to the embedded-hal version 1 release, with new trait defs.

