### PR TITLE
Add `set_offset`

### DIFF
--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -212,6 +212,10 @@ where
         Ok(raw as f32 * self.scale)
     }
 
+    fn set_offset(&mut self, offset: i32) {
+        self.offset = offset;
+    }
+
     fn set_scale(&mut self, scale: Self::Scale) {
         self.scale = scale;
     }

--- a/src/hx711.rs
+++ b/src/hx711.rs
@@ -212,7 +212,7 @@ where
         Ok(raw as f32 * self.scale)
     }
 
-    fn set_offset(&mut self, offset: i32) {
+    fn set_offset(&mut self, offset: Self::Offset) {
         self.offset = offset;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@ pub trait LoadCell {
     /// Zero the load cell offset by averaging `num_samples` readings
     fn tare(&mut self, num_samples: usize);
 
+    /// Set the load cell offset.
+    fn set_offset(&mut self, offset: i32);
+
     /// Get the load cell offset.
     fn get_offset(&self) -> Self::Offset;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub trait LoadCell {
     fn tare(&mut self, num_samples: usize);
 
     /// Set the load cell offset.
-    fn set_offset(&mut self, offset: i32);
+    fn set_offset(&mut self, offset: Self::Offset);
 
     /// Get the load cell offset.
     fn get_offset(&self) -> Self::Offset;


### PR DESCRIPTION
**Use case:**

When the ESP32 wakes up from deep sleep, it runs the code from the beginning. If `tare()` is used, a new offset will be created each time, which will produce a reading of 0 even if there is an object on the load cell. To overcome this, one could store a `TARE_OFFSET` variable in the RTC RAM and use that instead of `tare()`. To do that, we need a `set_offset()` function.

```
unsafe {
    if TARE_OFFSET != 0 {
        scale.set_offset(TARE_OFFSET);
    } else {
        scale.tare(32);
        TARE_OFFSET = scale.get_offset();
    }
    warn!("TARE_OFFSET after check: {}", TARE_OFFSET);
}
```

